### PR TITLE
use VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE const

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_functions.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_functions.wgsl
@@ -1,7 +1,11 @@
 #define_import_path bevy_pbr::mesh_functions
 
 #import bevy_pbr::{
-    mesh_view_bindings::{view, visibility_ranges},
+    mesh_view_bindings::{
+        view,
+        visibility_ranges,
+        VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE
+    },
     mesh_bindings::mesh,
     mesh_types::MESH_FLAGS_SIGN_DETERMINANT_MODEL_3X3_BIT,
     view_transformations::position_world_to_clip,
@@ -94,8 +98,8 @@ fn get_visibility_range_dither_level(instance_index: u32, world_position: vec4<f
     // If we're using a storage buffer, then the length is variable.
     let visibility_buffer_array_len = arrayLength(&visibility_ranges);
 #else   // AVAILABLE_STORAGE_BUFFER_BINDINGS >= 6
-    // If we're using a uniform buffer, then the length is *exactly* 64.
-    let visibility_buffer_array_len = 64u;
+    // If we're using a uniform buffer, then the length is constant
+    let visibility_buffer_array_len = VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE;
 #endif  // AVAILABLE_STORAGE_BUFFER_BINDINGS >= 6
 
     let visibility_buffer_index = mesh[instance_index].flags & 0xffffu;

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -40,7 +40,8 @@
 #if AVAILABLE_STORAGE_BUFFER_BINDINGS >= 6
 @group(0) @binding(12) var<storage> visibility_ranges: array<vec4<f32>>;
 #else
-@group(0) @binding(12) var<uniform> visibility_ranges: array<vec4<f32>, 64u>;
+const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: u32 = 64u;
+@group(0) @binding(12) var<uniform> visibility_ranges: array<vec4<f32>, VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE>;
 #endif
 
 @group(0) @binding(13) var screen_space_ambient_occlusion_texture: texture_2d<f32>;

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -35,12 +35,10 @@
 @group(0) @binding(10) var<uniform> fog: types::Fog;
 @group(0) @binding(11) var<uniform> light_probes: types::LightProbes;
 
-// NB: If you change this `#if`, make sure to update the corresponding `#if` in
-// `mesh_functions.wgsl` too.
+const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: u32 = 64u;
 #if AVAILABLE_STORAGE_BUFFER_BINDINGS >= 6
 @group(0) @binding(12) var<storage> visibility_ranges: array<vec4<f32>>;
 #else
-const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: u32 = 64u;
 @group(0) @binding(12) var<uniform> visibility_ranges: array<vec4<f32>, VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE>;
 #endif
 


### PR DESCRIPTION
Instead of using an hardcoded value use a `const` for the size.

I didn't put the const behind the ifdef because I don't want to break the import statement. Currently naga_oil just ignores it, so it doesn't matter right now but if it ever actually checks that the import is valid before processing it, it would break. Alternatively we could just set it to 0 in the dynamic case.

This doesn't have to be merged, it's just an alternative solution I wanted to explore.
