### PR TITLE
Fix DX12 instance index issues with batched morph targets and skins

### DIFF
--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -159,11 +159,15 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
         vertex_no_morph.instance_index
     );
 #else   // HAS_PREVIOUS_SKIN
-    let prev_model = mesh_functions::get_previous_world_from_local(prev_vertex.instance_index);
+    // Use vertex_no_morph.instance_index instead of prev_vertex.instance_index to work around a wgpu dx12 bug.
+    // See https://github.com/gfx-rs/naga/issues/2416
+    let prev_model = mesh_functions::get_previous_world_from_local(vertex_no_morph.instance_index);
 #endif  // HAS_PREVIOUS_SKIN
 
 #else   // SKINNED
-    let prev_model = mesh_functions::get_previous_world_from_local(prev_vertex.instance_index);
+    // Use vertex_no_morph.instance_index instead of prev_vertex.instance_index to work around a wgpu dx12 bug.
+    // See https://github.com/gfx-rs/naga/issues/2416
+    let prev_model = mesh_functions::get_previous_world_from_local(vertex_no_morph.instance_index);
 #endif  // SKINNED
 
     out.previous_world_position = mesh_functions::mesh_position_local_to_world(

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -77,14 +77,14 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     let mesh_world_from_local = mesh_functions::get_world_from_local(vertex_no_morph.instance_index);
 
 #ifdef SKINNED
+    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+    // See https://github.com/gfx-rs/naga/issues/2416
     var world_from_local = skinning::skin_model(
         vertex.joint_indices,
         vertex.joint_weights,
         vertex_no_morph.instance_index
     );
 #else // SKINNED
-    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
-    // See https://github.com/gfx-rs/naga/issues/2416
     var world_from_local = mesh_world_from_local;
 #endif // SKINNED
 

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -46,14 +46,14 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     let mesh_world_from_local = mesh_functions::get_world_from_local(vertex_no_morph.instance_index);
 
 #ifdef SKINNED
+    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+    // See https://github.com/gfx-rs/naga/issues/2416 .
     var world_from_local = skinning::skin_model(
         vertex.joint_indices,
         vertex.joint_weights,
         vertex_no_morph.instance_index
     );
 #else
-    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
-    // See https://github.com/gfx-rs/naga/issues/2416 .
     var world_from_local = mesh_world_from_local;
 #endif
 

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -8,23 +8,25 @@
 }
 
 #ifdef MORPH_TARGETS
-fn morph_vertex(vertex_in: Vertex) -> Vertex {
+// The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
+// See https://github.com/gfx-rs/naga/issues/2416
+fn morph_vertex(vertex_in: Vertex, instance_index: u32) -> Vertex {
     var vertex = vertex_in;
-    let first_vertex = mesh[vertex.instance_index].first_vertex_index;
+    let first_vertex = mesh[instance_index].first_vertex_index;
     let vertex_index = vertex.index - first_vertex;
 
-    let weight_count = bevy_pbr::morph::layer_count(vertex.instance_index);
+    let weight_count = bevy_pbr::morph::layer_count(instance_index);
     for (var i: u32 = 0u; i < weight_count; i ++) {
-        let weight = bevy_pbr::morph::weight_at(i, vertex.instance_index);
+        let weight = bevy_pbr::morph::weight_at(i, instance_index);
         if weight == 0.0 {
             continue;
         }
-        vertex.position += weight * morph_position(vertex_index, i, vertex.instance_index);
+        vertex.position += weight * morph_position(vertex_index, i, instance_index);
 #ifdef VERTEX_NORMALS
-        vertex.normal += weight * morph_normal(vertex_index, i, vertex.instance_index);
+        vertex.normal += weight * morph_normal(vertex_index, i, instance_index);
 #endif
 #ifdef VERTEX_TANGENTS
-        vertex.tangent += vec4(weight * morph_tangent(vertex_index, i, vertex.instance_index), 0.0);
+        vertex.tangent += vec4(weight * morph_tangent(vertex_index, i, instance_index), 0.0);
 #endif
     }
     return vertex;
@@ -36,7 +38,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     var out: VertexOutput;
 
 #ifdef MORPH_TARGETS
-    var vertex = morph_vertex(vertex_no_morph);
+    var vertex = morph_vertex(vertex_no_morph, vertex_no_morph.instance_index);
 #else
     var vertex = vertex_no_morph;
 #endif


### PR DESCRIPTION
This is a patch for https://github.com/bevyengine/bevy/pull/23023. I found that morph targets were sometimes broken but only with the DX12 backend (Win10, Nvidia 4060). Seems like a known issue and just needed to be applied to morphs as well.

Also fixes a case where skinned meshes might have had the same problem, although I didn't repro.