### PR TITLE
`many_morph_targets` spawning variations

### DIFF
--- a/examples/stress_tests/many_morph_targets.rs
+++ b/examples/stress_tests/many_morph_targets.rs
@@ -66,24 +66,42 @@ impl FromStr for ArgCamera {
     }
 }
 
-/// Controls how quickly the meshes spawn.
+/// Controls how the meshes spawn.
 #[derive(PartialEq)]
-enum ArgSpawnRate {
+enum ArgSpawning {
     /// All meshes will spawn in one frame.
     Instant,
 
     /// One mesh will spawn per frame.
-    Slow,
+    Gradual,
+
+    /// Spawn one mesh per frame in a consistent order until all are spawned,
+    /// then despawn one mesh per frame in the same order, and repeat.
+    RegularCycle,
+
+    /// Spawn one mesh per frame in a random order until all are spawned, then
+    /// despawn one mesh per frame in a random order, and repeat.
+    RandomCycle,
+
+    /// All meshes will spawn in one frame, and after that one mesh will spawn
+    /// and one mesh will despawn per frame.
+    RandomSteady,
 }
 
-impl FromStr for ArgSpawnRate {
+impl FromStr for ArgSpawning {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "instant" => Ok(Self::Instant),
-            "slow" => Ok(Self::Slow),
-            _ => Err("must be 'instant' or 'slow'".into()),
+            "gradual" => Ok(Self::Gradual),
+            "regular-cycle" => Ok(Self::RegularCycle),
+            "random-cycle" => Ok(Self::RandomCycle),
+            "random-steady" => Ok(Self::RandomSteady),
+            _ => Err(
+                "must be 'instant', 'gradual', 'regular-cycle', 'random-cycle', or 'random-steady'"
+                    .into(),
+            ),
         }
     }
 }
@@ -103,9 +121,9 @@ struct Args {
     #[argh(option, default = "ArgCamera::Near")]
     camera: ArgCamera,
 
-    /// options: 'instant', 'slow' - default = 'instant'
-    #[argh(option, default = "ArgSpawnRate::Instant")]
-    spawn_rate: ArgSpawnRate,
+    /// options: 'instant', 'gradual', 'regular-cycle', 'random-cycle', 'random-steady' - default = 'instant'
+    #[argh(option, default = "ArgSpawning::Instant")]
+    spawning: ArgSpawning,
 }
 
 fn main() {
@@ -134,14 +152,19 @@ fn main() {
             brightness: 1000.0,
             ..Default::default()
         })
+        .insert_resource(MorphAssets::default())
+        .insert_resource(Rng(ChaCha8Rng::seed_from_u64(856673)))
+        .insert_resource(State::new(&args))
         .insert_resource(args)
-        .insert_resource(State {
-            spawned_count: 0,
-            rng: ChaCha8Rng::seed_from_u64(856673),
-        })
         .add_systems(Startup, setup)
         .add_systems(Update, update)
         .run();
+}
+
+#[derive(Resource, Default)]
+struct MorphAssets {
+    scene: Handle<Scene>,
+    animations: Vec<(Handle<AnimationGraph>, AnimationNodeIndex)>,
 }
 
 #[derive(Component, Clone)]
@@ -151,15 +174,6 @@ struct AnimationToPlay {
     speed: f32,
 }
 
-impl AnimationToPlay {
-    fn with_speed(&self, speed: f32) -> Self {
-        AnimationToPlay {
-            speed,
-            ..self.clone()
-        }
-    }
-}
-
 fn dims(count: usize) -> (usize, usize) {
     let x_dim = ((count as f32).sqrt().ceil() as usize).max(1);
     let y_dim = count.div_ceil(x_dim);
@@ -167,8 +181,15 @@ fn dims(count: usize) -> (usize, usize) {
     (x_dim, y_dim)
 }
 
-fn setup(args: Res<Args>, mut commands: Commands) {
-    let (x_dim, _) = dims(args.count);
+fn setup(
+    args: Res<Args>,
+    mut commands: Commands,
+    mut assets: ResMut<MorphAssets>,
+    asset_server: Res<AssetServer>,
+    mut graphs: ResMut<Assets<AnimationGraph>>,
+    state: Res<State>,
+) {
+    let (x_dim, _) = dims(state.slot_count);
 
     commands.spawn((
         DirectionalLight::default(),
@@ -185,73 +206,143 @@ fn setup(args: Res<Args>, mut commands: Commands) {
         Camera3d::default(),
         Transform::from_xyz(0.0, 0.0, camera_distance).looking_at(Vec3::ZERO, Vec3::Y),
     ));
+
+    const ASSET_PATH: &str = "models/animated/MorphStressTest.gltf";
+
+    *assets = MorphAssets {
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(ASSET_PATH)),
+        animations: (0..3)
+            .map(|gltf_index| {
+                let (graph, index) = AnimationGraph::from_clip(
+                    asset_server.load(GltfAssetLabel::Animation(gltf_index).from_asset(ASSET_PATH)),
+                );
+                (graphs.add(graph), index)
+            })
+            .collect::<Vec<_>>(),
+    }
+}
+
+enum CycleState {
+    Spawn,
+    Despawn,
 }
 
 #[derive(Resource)]
 struct State {
-    spawned_count: usize,
-    rng: ChaCha8Rng,
+    ticks: usize,
+    slot_count: usize,
+    spawned: Vec<(usize, Entity)>,
+    despawned: Vec<usize>,
+    cycle: CycleState,
+}
+
+impl State {
+    fn new(args: &Args) -> State {
+        // The `RandomSteady` case allocates double the number of slots but only
+        // keeps half occupied.
+        let slot_count = match args.spawning {
+            ArgSpawning::RandomSteady => args.count * 2,
+            _ => args.count,
+        };
+
+        State {
+            ticks: 0,
+            slot_count,
+            spawned: Default::default(),
+            despawned: (0..slot_count).collect::<Vec<_>>(),
+            cycle: CycleState::Spawn,
+        }
+    }
+}
+
+#[derive(Resource)]
+struct Rng(ChaCha8Rng);
+
+// Randomly take `count` entries from the given `Vec` and return them.
+fn take_random<T>(rng: &mut ChaCha8Rng, from: &mut Vec<T>, count: usize) -> Vec<T> {
+    (0..count)
+        .map(|_| from.swap_remove(rng.random_range(..from.len())))
+        .collect()
 }
 
 fn update(
     args: Res<Args>,
-    asset_server: Res<AssetServer>,
-    mut graphs: ResMut<Assets<AnimationGraph>>,
     mut commands: Commands,
     mut state: ResMut<State>,
+    mut rng: ResMut<Rng>,
+    assets: Res<MorphAssets>,
 ) {
-    let target_count = match args.spawn_rate {
-        ArgSpawnRate::Instant => args.count,
-        ArgSpawnRate::Slow => args.count.min(state.spawned_count + 1),
-    };
+    state.ticks += 1;
 
-    if state.spawned_count == target_count {
-        return;
+    if state.spawned.is_empty() {
+        state.cycle = CycleState::Spawn;
+    } else if state.despawned.is_empty() {
+        state.cycle = CycleState::Despawn;
     }
 
-    const ASSET_PATH: &str = "models/animated/MorphStressTest.gltf";
+    let mut to_spawn = Vec::<usize>::default();
+    let mut to_despawn = Vec::<(usize, Entity)>::default();
 
-    let scene = SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset(ASSET_PATH)));
-
-    let animations = (0..3)
-        .map(|gltf_index| {
-            let (graph, index) = AnimationGraph::from_clip(
-                asset_server.load(GltfAssetLabel::Animation(gltf_index).from_asset(ASSET_PATH)),
-            );
-            AnimationToPlay {
-                graph_handle: graphs.add(graph),
-                index,
-                speed: 1.0,
+    match args.spawning {
+        ArgSpawning::Instant => to_spawn = std::mem::take(&mut state.despawned),
+        ArgSpawning::Gradual => to_spawn = state.despawned.pop().into_iter().collect(),
+        ArgSpawning::RegularCycle => match state.cycle {
+            CycleState::Spawn => to_spawn.push(state.despawned.pop().unwrap()),
+            CycleState::Despawn => to_despawn.push(state.spawned.pop().unwrap()),
+        },
+        ArgSpawning::RandomCycle => match state.cycle {
+            CycleState::Spawn => to_spawn = take_random(&mut rng.0, &mut state.despawned, 1),
+            CycleState::Despawn => to_despawn = take_random(&mut rng.0, &mut state.spawned, 1),
+        },
+        ArgSpawning::RandomSteady => {
+            if state.spawned.is_empty() {
+                let spawn_count = state.slot_count / 2;
+                to_spawn = take_random(&mut rng.0, &mut state.despawned, spawn_count);
+            } else {
+                to_spawn = take_random(&mut rng.0, &mut state.despawned, 1);
+                to_despawn = take_random(&mut rng.0, &mut state.spawned, 1);
             }
-        })
-        .collect::<Vec<_>>();
+        }
+    }
 
-    // Arrange the meshes in a grid.
+    for (mesh_index, entity) in to_despawn {
+        commands.entity(entity).despawn();
+        state.despawned.push(mesh_index);
+    }
 
-    let (x_dim, y_dim) = dims(args.count);
+    for mesh_index in to_spawn {
+        // Arrange the meshes in a grid.
 
-    for mesh_index in state.spawned_count..target_count {
-        let animation = animations[mesh_index.rem_euclid(animations.len())].clone();
+        let (x_dim, y_dim) = dims(state.slot_count);
 
         let x = 2.5 + (5.0 * ((mesh_index.rem_euclid(x_dim) as f32) - ((x_dim as f32) * 0.5)));
         let y = -2.2 - (3.0 * ((mesh_index.div_euclid(x_dim) as f32) - ((y_dim as f32) * 0.5)));
 
-        // Randomly vary the animation speed so that the number of morph targets
+        // Vary the animation speed so that the number of morph targets
         // active on each frame is more likely to be stable.
 
-        let animation_speed = state.rng.random_range(0.5..=1.5);
+        let speed = ((mesh_index as f32) * 0.1).rem_euclid(1.0) + 0.5;
 
-        commands
+        let animation_asset =
+            assets.animations[mesh_index.rem_euclid(assets.animations.len())].clone();
+        let animation = AnimationToPlay {
+            graph_handle: animation_asset.0.clone(),
+            index: animation_asset.1,
+            speed,
+        };
+
+        let entity = commands
             .spawn((
-                animation.with_speed(animation_speed),
-                scene.clone(),
+                animation,
                 Transform::from_xyz(x, y, 0.0),
+                SceneRoot(assets.scene.clone()),
             ))
             .observe(play_animation)
-            .observe(set_weights);
-    }
+            .observe(set_weights)
+            .id();
 
-    state.spawned_count = target_count;
+        state.spawned.push((mesh_index, entity));
+    }
 }
 
 fn play_animation(


### PR DESCRIPTION
Optional patch for https://github.com/bevyengine/bevy/pull/23023 - adds spawning options to test both adding and removing morph target meshes over time. 