### PR TITLE
Add list literal support to BSN grammar

### DIFF
--- a/crates/bevy_scene2/src/dynamic_bsn.rs
+++ b/crates/bevy_scene2/src/dynamic_bsn.rs
@@ -81,6 +81,7 @@ pub enum BsnExpr {
     FloatLit(f64),
     BoolLit(bool),
     IntLit(i128),
+    List(Vec<Entity>),
 }
 
 impl BsnSymbol {
@@ -586,6 +587,10 @@ impl BsnAst {
                     return Ok(reflect.into_partial_reflect());
                 }
                 Err(DynamicBsnLoaderError::TypeMismatch)
+            }
+
+            BsnExpr::List(_) => {
+                todo!()
             }
 
             BsnExpr::IntLit(int_lit) => {

--- a/crates/bevy_scene2/src/dynamic_bsn_grammar.lalrpop
+++ b/crates/bevy_scene2/src/dynamic_bsn_grammar.lalrpop
@@ -77,6 +77,12 @@ Expr: Entity = {
     <f:"float_lit"> => ast.borrow_mut().create_expr(BsnExpr::FloatLit(f)),
     <b:"bool_lit"> => ast.borrow_mut().create_expr(BsnExpr::BoolLit(b)),
     <i:"int_lit"> => ast.borrow_mut().create_expr(BsnExpr::IntLit(i)),
+    "[" <n:NamedTupleArgsInner> ","? "]" => {
+        ast.borrow_mut().create_expr(BsnExpr::List(n))
+    },
+    "[" "]" => {
+        ast.borrow_mut().create_expr(BsnExpr::List(Vec::new()))
+    },
 };
 
 Relation: BsnRelation = {


### PR DESCRIPTION
Adds a List variant to BsnExpr and list productions to the Expr grammar rule so list fields round-trip through BSN.