### PR TITLE
Support entity names with spaces in BSN

### DIFF
--- a/crates/bevy_scene2/src/dynamic_bsn_grammar.lalrpop
+++ b/crates/bevy_scene2/src/dynamic_bsn_grammar.lalrpop
@@ -30,6 +30,7 @@ pub Patch: Entity = {
 
 Name: String = {
     "#" <i:"ident"> => i,
+    "#" <s:"string_lit"> => s,
 };
 
 Base: String = {


### PR DESCRIPTION
## Summary
- Adds quoted string support for entity names: `#"Brush Group"` 
- Single-word names like `#Sun` continue to work unchanged

## Motivation
Entity names with spaces need quoting to round-trip through BSN files.